### PR TITLE
Added support for the WPML plugins

### DIFF
--- a/svn/trunk/html/count.php
+++ b/svn/trunk/html/count.php
@@ -19,6 +19,12 @@ include 'variables.php';
     window.addEventListener('load', function() {
         hyvorTalkCommentCounts.load({
         "website-id": HYVOR_TALK_WEBSITE,
+        
+        // WPML: Add language parameter
+        <?php if ( class_exists('Sitepress') && ! is_null( apply_filters( 'wpml_current_language', NULL ) ) ) { ?> 
+            "language": "<?php echo esc_attr(apply_filters( 'wpml_current_language', NULL )); ?>"	
+        <?php } ?>
+
         })
     });
 </script>

--- a/svn/trunk/html/v3-component.php
+++ b/svn/trunk/html/v3-component.php
@@ -32,6 +32,10 @@ if ($ssoData) {
 ?>
 
 <hyvor-talk-comments
+    <?php if ( class_exists('Sitepress') ) { ?>
+        page-language="<?php echo esc_attr(apply_filters( 'wpml_current_language', NULL )); ?>"
+    <?php }?>
+
     website-id="<?php echo esc_attr($websiteId) ?>"
     page-id="<?php echo $var['identifier'] === false ? '' : esc_attr($var['identifier']) ?>"
     sso-user="<?php echo esc_attr($userData) ?>"


### PR DESCRIPTION
Hi there, this is Diego from the WPML Compatibility team.

We got a internal report for a compatibility issue, where the comments count string (from the [hyvor-talk-comments-count] shortcode) was not being translated to the secondary languages.

I did some tests with the plugin and found 2 files where we could add support for the WPML languages. So I created this PR.

These are the documentation links that I am taking into account:
- https://talk.hyvor.com/docs/language#supportedlanguages
- https://talk.hyvor.com/docs/comment-counts#language